### PR TITLE
Mudança da versão da dependência HTTP

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  http: ^0.12.0+2
+  http: ^0.13.0
   xml2json: ^4.1.1


### PR DESCRIPTION
Incompatibilidade com a dependência google_fonts ^2.0.0 que exige a versão 0.13.0 do HTTP